### PR TITLE
Minor typos in advanced-android-textview

### DIFF
--- a/advanced-android-textview/index.html
+++ b/advanced-android-textview/index.html
@@ -422,21 +422,20 @@ String html = getString(R.string.from_html_text);
 textView.setMovementMethod(
     LinkMovementMethod.getInstance());
 textView.setText(Html.fromHtml(
-    html, new ResouroceImageGetter(this), null));
+    html, new ResourceImageGetter(this), null));
               </code></pre>
         </section>
 
         <section>
-          <h2>ResouroceImageGetter</h2>
+          <h2>ResourceImageGetter</h2>
               <pre style="width: auto"><code data-trim class="larger">
-private static class ResouroceImageGetter
+private static class ResourceImageGetter
     implements Html.ImageGetter {
   // Constructor takes a Context
   public Drawable getDrawable(String source) {
     int path = context.getResources().getIdentifier(
-        source, "drawable", BuildConfig.APPLICATION_ID);
-    Drawable drawable
-      = context.getResources().getDrawable(path);
+        source, "drawable", context.getPackageName());
+    Drawable drawable = ContextCompat.getDrawable(context, path);
     drawable.setBounds(0, 0,
        drawable.getIntrinsicWidth(),
        drawable.getIntrinsicHeight());


### PR DESCRIPTION
Also the reveal highlight plugin may need an update, it detects [this code](https://chiuki.github.io/advanced-android-textview/#/58) to be erlang and cannot highlight it correctly. Notice the colors of class names and `textView`.

![image](https://cloud.githubusercontent.com/assets/2906988/17020749/9e50d2f0-4f43-11e6-82db-68fb78c846e5.png)
